### PR TITLE
remove GitHub handles comments

### DIFF
--- a/sig-standardization/20251002.md
+++ b/sig-standardization/20251002.md
@@ -2,7 +2,6 @@
 
 ### Participants
 
-<!-- GitHub handles preferred -->
 - @depressiveRobot
 - @garloff
 - @matfechner

--- a/sig-standardization/20251111.md
+++ b/sig-standardization/20251111.md
@@ -4,7 +4,6 @@
 
 ### Participants
 
-<!-- GitHub handles preferred -->
 - @depressiveRobot
 - @fzakfeld
 - @fkr

--- a/sig-standardization/20251118.md
+++ b/sig-standardization/20251118.md
@@ -2,7 +2,6 @@
 
 ### Participants
 
-<!-- GitHub handles preferred -->
 - @toothstone
 - @fkr
 - @depressiveRobot

--- a/sig-standardization/20251125.md
+++ b/sig-standardization/20251125.md
@@ -2,7 +2,6 @@
 
 ### Participants
 
-<!-- GitHub handles preferred -->
 - @mbuechse
 - @fzakfeld
 - @depressiveRobot


### PR DESCRIPTION
Small cosmetic cleanup PR that removes all GitHub handles HTML comments from SIG Std/Cert minutes.